### PR TITLE
basic tile data and screenblock memory interface

### DIFF
--- a/demo/src/Hello.adb
+++ b/demo/src/Hello.adb
@@ -4,6 +4,7 @@ with GBA.BIOS.Thumb;
 with GBA.BIOS.Memset;
 
 with GBA.Display;
+with GBA.Display.Tiles;
 with GBA.Display.Backgrounds;
 with GBA.Display.Objects;
 with GBA.Display.Palettes;

--- a/src/GBA.Display.Backgrounds.ads
+++ b/src/GBA.Display.Backgrounds.ads
@@ -1,18 +1,14 @@
 
 with GBA.Numerics;
 
+with GBA.Display.Tiles;
+use  GBA.Display.Tiles;
+
 with GBA.Display.Palettes;
 use  GBA.Display.Palettes;
 
 
 package GBA.Display.Backgrounds is
-
-  type Tile_Block_Index is mod 4
-    with Size => 2;
-
-  type Data_Block_Index is mod 32
-    with Size => 5;
-
 
   type Boundary_Behavior is
     ( Cutoff
@@ -50,7 +46,7 @@ package GBA.Display.Backgrounds is
       Tile_Block    : Tile_Block_Index;
       Enable_Mosaic : Boolean;
       Color_Mode    : Palette_Mode;
-      Data_Block    : Data_Block_Index;
+      Screen_Block  : Screen_Block_Index;
       Boundary_Mode : Boundary_Behavior;
       Size          : BG_Size;
     end record
@@ -62,7 +58,7 @@ package GBA.Display.Backgrounds is
       Tile_Block    at 0 range 2 .. 3;
       Enable_Mosaic at 0 range 6 .. 6;
       Color_Mode    at 0 range 7 .. 7;
-      Data_Block    at 1 range 0 .. 4;
+      Screen_Block  at 1 range 0 .. 4;
       Boundary_Mode at 1 range 5 .. 5;
       Size          at 1 range 6 .. 7;
     end record;

--- a/src/GBA.Display.Objects.ads
+++ b/src/GBA.Display.Objects.ads
@@ -1,4 +1,7 @@
 
+with GBA.Display.Tiles;
+use  GBA.Display.Tiles;
+
 with GBA.Display.Palettes;
 use  GBA.Display.Palettes;
 
@@ -92,9 +95,6 @@ package GBA.Display.Objects is
 
   procedure As_Shape_And_Scale (Size : OBJ_Size; Shape : out OBJ_Shape; Scale : out OBJ_Scale)
     with Inline_Always;
-
-
-  type OBJ_Tile_Index is range 0 .. 1023;
 
 
   type OBJ_Affine_Transform_Index is range 0 .. 31

--- a/src/GBA.Display.Tiles.adb
+++ b/src/GBA.Display.Tiles.adb
@@ -1,0 +1,17 @@
+
+with System;
+use type System.Address;
+
+package body GBA.Display.Tiles is
+
+  function Tile_Block_Address (Ix : Tile_Block_Index) return Address is
+  begin
+    return Video_RAM_Address'First + (Address (Ix) * 16#4000#);
+  end;
+
+  function Screen_Block_Address (Ix : Screen_Block_Index) return Address is
+  begin
+    return Video_RAM_Address'First + (Address (Ix) * 16#800#);
+  end;
+
+end GBA.Display.Tiles;

--- a/src/GBA.Display.Tiles.ads
+++ b/src/GBA.Display.Tiles.ads
@@ -1,0 +1,124 @@
+
+with GBA.Memory;
+use  GBA.Memory;
+
+with GBA.Display.Palettes;
+use  GBA.Display.Palettes;
+
+
+package GBA.Display.Tiles is
+
+  type Tile_Data_4 is array (1 .. 8, 1 .. 8) of Color_Index_16
+    with Pack, Size => 32 * 8;
+
+  type Tile_Data_8 is array (1 .. 8, 1 .. 8) of Color_Index_256
+    with Pack, Size => 64 * 8;
+
+
+  type Tile_Block_Index is range 0 .. 3
+    with Size => 2;
+
+  type Screen_Block_Index is range 0 .. 31
+    with Size => 5;
+
+
+  function Tile_Block_Address (Ix : Tile_Block_Index) return Address
+    with Pure_Function, Inline_Always;
+
+  function Screen_Block_Address (Ix : Screen_Block_Index) return Address
+    with Pure_Function, Inline_Always;
+
+
+
+  -- These types are defined separately for a couple of reasons:
+  --   - Indexing into different regions of tile data
+  --   - Representing 64-byte offsets in 256-color mode for OBJ,
+  --     but always 32-byte offsets for BGs.
+
+  type BG_Tile_Index is range 0 .. 1023
+      with Size => 10;
+
+  type OBJ_Tile_Index is range 0 .. 1023
+      with Size => 10;
+
+
+  type Screen_Entry_16 is
+    record
+      Tile            : BG_Tile_Index;
+      Flip_Horizontal : Boolean;
+      Flip_Vertical   : Boolean;
+      Palette_Index   : Palette_Index_16; -- ignored in 256-color mode
+    end record
+      with Size => 16;
+
+  for Screen_Entry_16 use
+    record
+      Tile            at 0 range 0  .. 9;
+      Flip_Horizontal at 0 range 10 .. 10;
+      Flip_Vertical   at 0 range 11 .. 11;
+      Palette_Index   at 0 range 12 .. 15;
+    end record;
+
+
+  subtype Affine_BG_Tile_Index is
+    BG_Tile_Index range 0 .. 255;
+
+  type Screen_Entry_8 is
+    record
+      Tile : Affine_BG_Tile_Index;
+    end record
+      with Size => 8;
+
+  for Screen_Entry_8 use
+    record
+      Tile at 0 range 0 .. 7;
+    end record;
+
+
+
+  OBJ_Tile_Memory_Start : constant Video_RAM_Address := 16#6010000#;
+
+  OBJ_Tile_Memory_4 : array (OBJ_Tile_Index) of Tile_Data_4
+    with Import, Volatile, Address => OBJ_Tile_Memory_Start;
+
+  OBJ_Tile_Memory_8 : array (OBJ_Tile_Index range 0 .. 511) of Tile_Data_8
+    with Import, Volatile, Address => OBJ_Tile_Memory_Start;
+
+
+
+  type Tile_Block_4 is
+    array (BG_Tile_Index range <>) of Tile_Data_4
+      with Pack;
+
+  type Tile_Block_4_Ptr is access all Tile_Block_4
+    with Storage_Size => 0;
+
+
+  type Tile_Block_8 is
+    array (BG_Tile_Index range <>) of Tile_Data_8
+      with Pack;
+
+  type Tile_Block_8_Ptr is access all Tile_Block_8
+    with Storage_Size => 0;
+
+
+  type Screen_Block_16 is
+    array (1 .. 32, 1 .. 32) of Screen_Entry_16
+      with Pack;
+
+  type Screen_Block_16_Ptr is access all Screen_Block_16
+    with Storage_Size => 0;
+
+
+  -- Affine background map data is variably-sized.
+  -- Rather than 32x32 chunks, the whole map is
+  -- a large square, of up to 128x128 tiles.
+
+  type Screen_Block_8 is
+    array (Positive range <>, Positive range <>) of Screen_Entry_8
+      with Pack;
+
+  type Screen_Block_8_Ptr is access all Screen_Block_8
+    with Storage_Size => 0;
+
+end GBA.Display.Tiles;


### PR DESCRIPTION
For now, 2d view of tile VRAM is considered relatively unimportant.
By default most use cases will use 1d sprite tile order anyway.
In such a case as it is necessary, an array type can be declared to handle it.

Closes #2 